### PR TITLE
feat: 디테일 페이지 구현(#9)

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,14 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-function useFetch({ options = {}, query }) {
+function useFetch({ options = {}, queryFn, queryKey = [] }) {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  const queryFnRef = useRef(queryFn);
+  queryFnRef.current = queryFn;
+
   const serializedOptions = JSON.stringify(options);
+  const serializedQueryKey = JSON.stringify(queryKey);
 
   useEffect(() => {
-    if (!query) {
+    if (!queryFnRef.current) {
       setIsLoading(false);
       return;
     }
@@ -23,7 +27,7 @@ function useFetch({ options = {}, query }) {
       try {
         const parsedOptions = JSON.parse(serializedOptions);
 
-        const result = await query({
+        const result = await queryFnRef.current({
           ...parsedOptions,
           signal: controller.signal,
         });
@@ -45,7 +49,7 @@ function useFetch({ options = {}, query }) {
     return () => {
       controller.abort();
     };
-  }, [query, serializedOptions]);
+  }, [serializedQueryKey, serializedOptions]);
 
   return { data, error, isLoading };
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,9 +7,7 @@ import { BrowserRouter } from "react-router";
 import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>,
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
 );

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,3 +1,60 @@
+import { fetchMovieDetail } from "@api";
+import { TMDB_IMAGE_URL } from "@constants";
+import useFetch from "@hooks/useFetch";
+import { useParams } from "react-router";
+
 export const Detail = () => {
-  return <div>Detail</div>;
+  const { movieId } = useParams();
+
+  const { data, error, isLoading } = useFetch({
+    query: (options) => fetchMovieDetail({ movieId, ...options }),
+    queryKey: [movieId],
+  });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  const {
+    backdropPath,
+    genres = [],
+    overview,
+    title,
+    voteAverage,
+  } = data || {};
+
+  return (
+    <main>
+      <div>
+        <div>
+          <img alt={title} src={TMDB_IMAGE_URL + backdropPath} />
+        </div>
+        <article>
+          <header>
+            <div>
+              <p>Movie Detail</p>
+              <h1>{title}</h1>
+            </div>
+            <div>
+              <span>
+                {Number.isFinite(voteAverage) ? voteAverage.toFixed(1) : "N/A"}
+              </span>
+              <ul>
+                {genres.map((genre) => (
+                  <li key={genre.id ?? genre.name}>{genre.name}</li>
+                ))}
+              </ul>
+            </div>
+          </header>
+          <section>
+            <h2>줄거리</h2>
+            <p>{overview}</p>
+          </section>
+        </article>
+      </div>
+    </main>
+  );
 };

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -5,7 +5,6 @@ import { useParams } from "react-router";
 
 export const Detail = () => {
   const { id: movieId } = useParams();
-
   const { data, error, isLoading } = useFetch({
     queryFn: (options) => fetchMovieDetail({ movieId, ...options }),
     queryKey: [movieId],

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -4,10 +4,10 @@ import useFetch from "@hooks/useFetch";
 import { useParams } from "react-router";
 
 export const Detail = () => {
-  const { movieId } = useParams();
+  const { id: movieId } = useParams();
 
   const { data, error, isLoading } = useFetch({
-    query: (options) => fetchMovieDetail({ movieId, ...options }),
+    queryFn: (options) => fetchMovieDetail({ movieId, ...options }),
     queryKey: [movieId],
   });
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import { useFetch } from "@hooks";
 
 export const Home = () => {
   const { data, error, isLoading } = useFetch({
-    query: fetchPopularMovieList,
+    queryFn: fetchPopularMovieList,
   });
 
   if (isLoading) {


### PR DESCRIPTION
## 연관된 이슈

> #9

## 작업 내용

>디테일 페이지 구현

- Detail페이지 구현
- 영화 상세 정보 query 이용하여 API 요청
- 로딩과 에러 처리
- useFetch의 abortController 으로 로딩상태 표시 안됨 문제 strict mode 제거해 해결
- useRef에 queryFn 저장해 불필요한 리렌더링 막음
- Detail 페이지에서 useParams를 가져올때 id: movieId로 수정
- Detail 페이지에서 useFetch의 query를 queryFn으로 수정
