### PR TITLE
feat: 다크모드 구현(#23)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.17",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.554.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router": "^7.9.5",
@@ -4259,6 +4260,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.554.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.554.0.tgz",
+      "integrity": "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.17",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.554.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router": "^7.9.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { MainLayout } from "@components";
 import { ROUTE_PATHS } from "@constants";
+import ThemeProvider from "@contexts/ThemeProvider";
 import { Detail, Home, NotFound, Search } from "@pages";
 import { Route, Routes } from "react-router";
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,13 +24,15 @@ function App() {
   ];
 
   return (
-    <Routes>
-      <Route element={<MainLayout />}>
-        {ROUTES.map((route) => (
-          <Route element={route.element} key={route.path} path={route.path} />
-        ))}
-      </Route>
-    </Routes>
+    <ThemeProvider>
+      <Routes>
+        <Route element={<MainLayout />}>
+          {ROUTES.map((route) => (
+            <Route element={route.element} key={route.path} path={route.path} />
+          ))}
+        </Route>
+      </Routes>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,3 +8,4 @@ export { default as Carousel } from "./ui/Carousel";
 export { default as ErrorMessage } from "./ui/ErrorMessage";
 export { default as LoadingSpinner } from "./ui/LoadingSpinner";
 export { default as Skeleton } from "./ui/Skeleton";
+export { default as ThemeToggle } from "./ui/ThemeToggle";

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,19 +1,28 @@
 import { SearchBar } from "@components/index";
+import ThemeToggle from "@components/ui/ThemeToggle";
+import { ROUTE_PATHS } from "@constants/urls";
 import { Link } from "react-router";
 
 const Header = () => {
   return (
     <header>
-      <div className="mx-auto flex h-16 items-center justify-between bg-neutral-50 px-6 py-2">
+      <div className="mx-auto flex h-16 items-center justify-between bg-neutral-50 px-6 py-2 dark:bg-gray-900">
         <div className="flex flex-1 justify-start">
           <h1>
-            <Link>🎥 은이 무비</Link>
+            <Link
+              className="text-gray-900 dark:text-gray-100"
+              to={ROUTE_PATHS.HOME}
+            >
+              🎥 은이 무비
+            </Link>
           </h1>
         </div>
         <div className="flex flex-[1.5] justify-center">
           <SearchBar />
         </div>
-        <div className="flex flex-1 justify-end">right side</div>
+        <div className="flex flex-1 items-center justify-end">
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router";
 
 export default function MainLayout() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-gray-950">
       <Header />
       <main className="flex-1">
         <Outlet />

--- a/src/components/layout/SearchBar.jsx
+++ b/src/components/layout/SearchBar.jsx
@@ -109,7 +109,7 @@ export const SearchBar = () => {
     <div className="flex w-full items-center justify-center">
       <input
         // 디자인 (Tailwind CSS)
-        className="w-full rounded-md border border-gray-300 px-4 py-2 text-gray-600 focus:outline-none"
+        className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-600 focus:outline-none dark:border-gray-800 dark:text-gray-200 dark:placeholder:text-gray-400"
         // 타자 칠 때마다 handleInputChange 함수를 실행해요.
         onChange={handleInputChange}
         // 아무것도 없을 때 보여줄 안내 문구

--- a/src/components/movie/MovieCard.jsx
+++ b/src/components/movie/MovieCard.jsx
@@ -1,5 +1,6 @@
 import { ROUTE_HANDLERS, TMDB_IMAGE_URL } from "@constants";
 import { cn } from "@utils/cn";
+import { StarIcon } from "lucide-react";
 import { Link } from "react-router";
 
 const MovieCard = ({ movie }) => {
@@ -25,7 +26,8 @@ const MovieCard = ({ movie }) => {
             {movie.title}
           </h2>
           <p className="mt-1 flex items-center gap-1 text-xs text-yellow-400">
-            ⭐ {movie.voteAverage.toFixed(1)}
+            <StarIcon className="h-3 w-3 fill-current" />{" "}
+            {movie.voteAverage.toFixed(1)}
           </p>
         </div>
       </Link>

--- a/src/components/movie/MovieCard.jsx
+++ b/src/components/movie/MovieCard.jsx
@@ -24,7 +24,7 @@ const MovieCard = ({ movie }) => {
           <h2 className="line-clamp-2 text-sm font-semibold text-white">
             {movie.title}
           </h2>
-          <p className="mt-1 text-xs text-yellow-400">
+          <p className="mt-1 flex items-center gap-1 text-xs text-yellow-400">
             ⭐ {movie.voteAverage.toFixed(1)}
           </p>
         </div>

--- a/src/components/movie/NowPlayingCarousel.jsx
+++ b/src/components/movie/NowPlayingCarousel.jsx
@@ -34,11 +34,6 @@ const NowPlayingCarousel = () => {
         slidesPerView={4}
         spaceBetween={16}
       >
-        {data.results.map((movie) => (
-          <SwiperSlide key={movie.id}>
-            <MovieCard movie={movie} />
-          </SwiperSlide>
-        ))}
         {isLoading
           ? Array.from({ length: 8 }).map((_, index) => (
               <SwiperSlide key={index}>

--- a/src/components/movie/NowPlayingCarousel.jsx
+++ b/src/components/movie/NowPlayingCarousel.jsx
@@ -19,11 +19,11 @@ const NowPlayingCarousel = () => {
 
   return (
     <section className="w-full px-4">
-      <h1 className="mt-4 text-xl text-gray-700">상영중</h1>
+      <h1 className="mt-4 text-xl text-gray-700 dark:text-gray-200">상영중</h1>
       {isLoading ? (
         <p className="invisible text-sm text-gray-500">로딩중...</p>
       ) : (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-gray-500 dark:text-gray-500">
           {data.dates.minimum} - {data.dates.maximum}
         </p>
       )}

--- a/src/components/ui/Carousel.css
+++ b/src/components/ui/Carousel.css
@@ -148,4 +148,72 @@
       bottom: 0rem;
     }
   }
+
+  /* Dark mode styles*/
+  &.dark {
+    & .swiper-button-prev,
+    & .swiper-button-next {
+      background: rgba(30, 41, 59, 0.8);
+      border: 1.5px solid rgba(148, 163, 184, 0.3);
+
+      &:hover {
+        border: 2px solid rgb(148, 163, 184);
+      }
+
+      &::before {
+        border-top-color: #e2e8f0;
+        border-right-color: #e2e8f0;
+      }
+    }
+
+    & .swiper-button-disabled::before {
+      border-color: #475569;
+    }
+
+    &.swiper-pagination-bullet {
+      background-color: #475569;
+    }
+
+    &:hover {
+      background-color: #64748b;
+    }
+
+    &.swiper-pagination-bullet-active {
+      background-color: #e2e8f0;
+    }
+  }
+
+  @media (max-width: 640px) {
+    padding: 0.5rem 1.5rem;
+    padding-bottom: 3.5rem;
+
+    & .swiper-button-prev,
+    & .swiper-button-next {
+      width: 2.5rem;
+      height: 2.5rem;
+
+      &::before {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-width: 2px;
+      }
+
+      &:hover::before {
+        border-width: 2.5px;
+      }
+    }
+
+    & .swiper-button-prev {
+      right: 4.5rem;
+    }
+
+    & .swiper-button-next {
+      right: 1.5rem;
+    }
+
+    & .swiper-pagination {
+      right: 8rem;
+      bottom: 0rem;
+    }
+  }
 }

--- a/src/components/ui/Carousel.jsx
+++ b/src/components/ui/Carousel.jsx
@@ -1,11 +1,13 @@
-import { cn } from "@utils/cn";
-import { Autoplay, Navigation, Pagination } from "swiper/modules";
+import { THEME } from "@constants";
+import useTheme from "@hooks";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
-import { Swiper } from "swiper/react";
+import { cn } from "@utils/cn";
 
 import "./Carousel.css";
+import { Autoplay, Navigation, Pagination } from "swiper/modules";
+import { Swiper } from "swiper/react";
 
 const AUTO_PLAY_DELAY = 3000;
 const CUSTOM_CLASSES_CLASS = "custom-carousel";
@@ -21,6 +23,7 @@ const Carousel = ({
   spaceBetween = 16,
   swiperProps,
 }) => {
+  const { theme } = useTheme();
   const modules = [];
   if (navigation) {
     modules.push(Navigation);
@@ -49,7 +52,7 @@ const Carousel = ({
           : false
       }
       breakpoints={breakpoints || defaultBreakpoints}
-      className={cn(CUSTOM_CLASSES_CLASS, className)}
+      className={cn(CUSTOM_CLASSES_CLASS, theme === THEME.DARK, className)}
       loop={loop}
       modules={modules}
       navigation={navigation}

--- a/src/components/ui/Carousel.jsx
+++ b/src/components/ui/Carousel.jsx
@@ -1,5 +1,5 @@
 import { THEME } from "@constants";
-import useTheme from "@hooks";
+import { useTheme } from "@hooks";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";

--- a/src/components/ui/ErrorMessage.jsx
+++ b/src/components/ui/ErrorMessage.jsx
@@ -3,10 +3,14 @@ const ErrorMessage = ({ error, message }) => {
     message || error?.message || "알 수 없는 오류가 발생했습니다.";
 
   return (
-    <div className="flex h-[80vh] flex-1 items-center justify-center bg-neutral-50 p-8">
-      <div className="flex h-full max-h-[200px] w-full max-w-[300px] flex-col items-center justify-center rounded-lg border border-red-200 bg-red-50 px-6 py-4 text-center shadow-sm">
-        <p className="text-sm font-semibold text-red-800">오류 발생</p>
-        <p className="mt-1 text-sm text-red-600">{displayMessage}</p>
+    <div className="flex h-[80vh] flex-1 items-center justify-center bg-neutral-50 p-8 dark:bg-gray-950">
+      <div className="flex h-full max-h-[200px] w-full max-w-[300px] flex-col items-center justify-center rounded-lg border border-red-200 bg-red-50 px-6 py-4 text-center shadow-sm dark:border-red-800 dark:bg-red-950">
+        <p className="text-sm font-semibold text-red-800 dark:text-red-300">
+          오류 발생
+        </p>
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+          {displayMessage}
+        </p>
       </div>
     </div>
   );

--- a/src/components/ui/LoadingSpinner.jsx
+++ b/src/components/ui/LoadingSpinner.jsx
@@ -7,7 +7,7 @@ const LoadingSpinner = ({
 }) => {
   if (fullscreen) {
     return (
-      <div className="flex min-h-screen flex-1 items-center justify-center bg-neutral-50">
+      <div className="flex min-h-screen flex-1 items-center justify-center bg-neutral-50 dark:bg-gray-950">
         <ClipLoader color={color} loading={true} size={size} />
       </div>
     );

--- a/src/components/ui/Skeleton.jsx
+++ b/src/components/ui/Skeleton.jsx
@@ -3,7 +3,10 @@ import { cn } from "@utils/cn";
 const Skeleton = ({ className, ...props }) => {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-gray-300/20", className)}
+      className={cn(
+        "animate-pulse rounded-md bg-gray-300/20 dark:bg-gray-700/30",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/components/ui/ThemeToggle.jsx
+++ b/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,24 @@
+import { THEME } from "@constants";
+import { useTheme } from "@hooks";
+import { Moon as MoonIcon, Sun as SunIcon } from "lucide-react";
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      className="rounded-lg p-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+      onClick={toggleTheme}
+      type="button"
+    >
+      {theme === THEME.LIGHT ? (
+        <MoonIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+      ) : (
+        <SunIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+      )}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,2 @@
+export * from "./theme";
 export * from "./urls";

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -1,0 +1,4 @@
+export const THEME = {
+  DARK: "dark",
+  LIGHT: "light",
+};

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,7 @@
+import { THEME } from "@constants";
+import { createContext } from "react";
+
+export const ThemeContext = createContext({
+  theme: THEME.LIGHT,
+  toggleTheme: () => {},
+});

--- a/src/contexts/ThemeProvider.jsx
+++ b/src/contexts/ThemeProvider.jsx
@@ -1,0 +1,43 @@
+import { THEME } from "@constants";
+import { useEffect, useState } from "react";
+
+import { ThemeContext } from "./ThemeContext";
+
+const THEME_LOCAL_STORAGE_KEY = "theme";
+const DARK_CLASS_NAME = "dark";
+const MEDIA_QUERY_DARK_CLASS_NAME = "(prefers-color-scheme: dark)";
+
+const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    const savedTheme = localStorage.getItem(THEME_LOCAL_STORAGE_KEY);
+    if (savedTheme) {
+      return savedTheme;
+    }
+    if (window.matchMedia(MEDIA_QUERY_DARK_CLASS_NAME).matches) {
+      return THEME.DARK;
+    }
+    return THEME.LIGHT;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (theme === THEME.DARK) {
+      root.classList.add(DARK_CLASS_NAME);
+    } else {
+      root.classList.remove(DARK_CLASS_NAME);
+    }
+
+    localStorage.setItem(THEME_LOCAL_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) =>
+      prevTheme === THEME.LIGHT ? THEME.DARK : THEME.LIGHT,
+    );
+  };
+
+  return <ThemeContext value={{ theme, toggleTheme }}>{children}</ThemeContext>;
+};
+
+export default ThemeProvider;

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,0 +1,2 @@
+export { ThemeContext } from "./ThemeContext";
+export { default as ThemeProvider } from "./ThemeProvider";

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useDebounce } from "./useDebounce";
 export { default as useFetch } from "./useFetch";
+export { default as useTheme } from "./useTheme";

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,14 @@
+import { ThemeContext } from "@contexts";
+import { useContext } from "react";
+
+const useTheme = () => {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme은 ThemeProvider 내에서 사용해야 합니다.");
+  }
+
+  return context;
+};
+
+export default useTheme;

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -65,7 +65,7 @@ export const Detail = () => {
             </div>
           </header>
           <section className="rounded-3xl bg-white p-6 shadow-sm dark:bg-gray-800">
-            <h2 className="text-lg font-semibold text-neutral-100 dark:bg-gray-900">
+            <h2 className="text-lg font-semibold text-neutral-900 dark:bg-gray-900 dark:text-neutral-100">
               줄거리
             </h2>
             <p className="mt-3 leading-relaxed text-neutral-700 dark:text-gray-300">

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,7 +1,8 @@
 import { fetchMovieDetail } from "@api";
 import { ErrorMessage, LoadingSpinner } from "@components";
 import { TMDB_IMAGE_URL } from "@constants";
-import useFetch from "@hooks/useFetch";
+import { useFetch } from "@hooks";
+import { StarIcon } from "lucide-react";
 import { useParams } from "react-router";
 
 export const Detail = () => {
@@ -27,7 +28,7 @@ export const Detail = () => {
   } = data || {};
 
   return (
-    <main className="bg-neutral-50 pb-8 text-neutral-900">
+    <main className="bg-neutral-50 pt-8 pb-8 text-neutral-900 dark:bg-gray-950 dark:text-gray-100">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 lg:flex-row lg:items-start">
         <div className="flex w-full items-center justify-center lg:max-w-sm">
           <img
@@ -39,21 +40,22 @@ export const Detail = () => {
         <article className="flex w-full flex-1 flex-col gap-8">
           <header className="space-y-4">
             <div>
-              <p className="text-sm tracking-widest text-neutral-500 uppercase">
+              <p className="text-sm tracking-widest text-neutral-500 uppercase dark:text-gray-400">
                 Movie Detail
               </p>
-              <h1 className="mt-1 text-3xl leading-tight font-bold text-neutral-900 lg:text-4xl">
+              <h1 className="mt-1 text-3xl leading-tight font-bold text-neutral-900 lg:text-4xl dark:text-gray-100">
                 {title}
               </h1>
             </div>
             <div className="flex flex-wrap items-center gap-4">
-              <span className="flex items-center gap-2 rounded-full border border-yellow-400 px-3 text-sm text-yellow-500">
-                {Number.isFinite(voteAverage) ? voteAverage.toFixed(1) : "N/A"}
+              <span className="flex items-center gap-2 rounded-full border border-yellow-400 px-3 text-sm text-yellow-500 dark:border-yellow-400 dark:text-yellow-400">
+                <StarIcon className="h-3 w-3 fill-current" /> ?
+                {voteAverage.toFixed(1)}
               </span>
-              <ul className="flex flex-wrap gap-2 text-sm text-neutral-700">
+              <ul className="flex flex-wrap gap-2 text-sm text-neutral-700 dark:text-gray-300">
                 {genres.map((genre) => (
                   <li
-                    className="rounded-full bg-neutral-200 px-3 py-1"
+                    className="rounded-full bg-neutral-200 px-3 py-1 dark:bg-gray-700"
                     key={genre.id ?? genre.name}
                   >
                     {genre.name}
@@ -62,9 +64,13 @@ export const Detail = () => {
               </ul>
             </div>
           </header>
-          <section className="rounded-3xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">줄거리</h2>
-            <p className="mt-3 leading-relaxed text-neutral-700">{overview}</p>
+          <section className="rounded-3xl bg-white p-6 shadow-sm dark:bg-gray-800">
+            <h2 className="text-lg font-semibold text-neutral-900 dark:bg-gray-100">
+              줄거리
+            </h2>
+            <p className="mt-3 leading-relaxed text-neutral-700 dark:text-gray-300">
+              {overview}
+            </p>
           </section>
         </article>
       </div>

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -49,7 +49,7 @@ export const Detail = () => {
             </div>
             <div className="flex flex-wrap items-center gap-4">
               <span className="flex items-center gap-2 rounded-full border border-yellow-400 px-3 text-sm text-yellow-500 dark:border-yellow-400 dark:text-yellow-400">
-                <StarIcon className="h-3 w-3 fill-current" /> ?
+                <StarIcon className="h-3 w-3 fill-current" />
                 {voteAverage.toFixed(1)}
               </span>
               <ul className="flex flex-wrap gap-2 text-sm text-neutral-700 dark:text-gray-300">
@@ -65,7 +65,7 @@ export const Detail = () => {
             </div>
           </header>
           <section className="rounded-3xl bg-white p-6 shadow-sm dark:bg-gray-800">
-            <h2 className="text-lg font-semibold text-neutral-900 dark:bg-gray-100">
+            <h2 className="text-lg font-semibold text-neutral-100 dark:bg-gray-900">
               줄거리
             </h2>
             <p className="mt-3 leading-relaxed text-neutral-700 dark:text-gray-300">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -16,7 +16,7 @@ export const Home = () => {
   return (
     <div className="flex flex-col bg-neutral-50 dark:bg-gray-950">
       <NowPlayingCarousel />
-      <section className="mx-auto grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+      <section className="mx-auto gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
         <h1 className="px-6 text-xl text-gray-700 dark:text-gray-200">
           POPULAR MOVIES
         </h1>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -14,19 +14,21 @@ export const Home = () => {
   }
 
   return (
-    <div className="flex flex-col bg-neutral-50">
+    <div className="flex flex-col bg-neutral-50 dark:bg-gray-950">
       <NowPlayingCarousel />
       <section className="mx-auto grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-        {data?.results?.map((movie) => (
-          <MovieCard key={movie.id} movie={movie} />
-        ))}
-        {isLoading
-          ? Array.from({ length: 12 }).map((_, index) => (
-              <MovieCardSkeleton key={index} />
-            ))
-          : data?.results?.map((movie) => (
-              <MovieCard key={movie.id} movie={movie} />
-            ))}
+        <h1 className="px-6 text-xl text-gray-700 dark:text-gray-200">
+          POPULAR MOVIES
+        </h1>
+        <div className="mx-auto mt-1 grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {isLoading
+            ? Array.from({ length: 12 }).map((_, index) => (
+                <MovieCardSkeleton key={index} />
+              ))
+            : data?.results?.map((movie) => (
+                <MovieCard key={movie.id} movie={movie} />
+              ))}
+        </div>
       </section>
     </div>
   );

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,3 +1,15 @@
-export const NotFound = () => {
-  return <div>NotFound</div>;
+const NotFound = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 dark:bg-gray-950">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-gray-900 dark:text-gray-100">
+          404
+        </h1>
+        <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
+          페이지를 찾을 수 없습니다.
+        </p>
+      </div>
+    </div>
+  );
 };
+export default NotFound;

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -33,13 +33,15 @@ const Search = () => {
 
   if (!data?.results?.length) {
     return (
-      <div>
-        <p>검색 결과가 없습니다.</p>
+      <div className="flex flex-1 items-center justify-center bg-neutral-50 dark:bg-gray-950">
+        <p className="text-gray-500 dark:text-gray-400">
+          검색 결과가 없습니다.
+        </p>
       </div>
     );
   }
   return (
-    <div className="flex flex-col items-center bg-neutral-50">
+    <div className="flex flex-col items-center bg-neutral-50 dark:bg-gray-950">
       <section className="mx-auto grid grid-cols-2 gap-4 px-4 pt-8 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
         {data.results.map((movie) => (
           <MovieCard key={movie.id} movie={movie} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
 export * from "./Detail";
 export * from "./Home";
-export * from "./NotFound";
+export { default as NotFound } from "./NotFound";
 export { default as Search } from "./Search";

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,11 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
 import { defineConfig } from "vite";
 
-const __dirname = path.resolve();
-
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],


### PR DESCRIPTION
## 연관된 이슈

> #23

## 작업 내용

> 다크모드, 라이트모드 구현

- lucide-react 설치
- ThemeToggle, theme, ThemeContext, ThemeProvider 컴포넌트 생성 및 적용
- MainLayout, SearchBar, NowPlayingCarousel, Home, Detail, NotFound, Search, ErrorMessage, LoadingSpinner, Skeleton 다크모드 적용
- Lucide 아이콘 라이브러리 설치 및 통일
- 오류 수정 및 tailwind.css 보강
